### PR TITLE
Automatic update of dependency thoth-storages from 0.0.28 to 0.0.29

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b85e163ca71aec1ba6a9d74facaa54c571213ffb881b2412d279dc8f2e977fa5"
+            "sha256": "bc539eaae3bdd5d8db117b5692b4aa9f75b873763093b2447dff29cc3685c928"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -292,11 +292,11 @@
         },
         "thoth-storages": {
             "hashes": [
-                "sha256:44d154ba9fdfec6f4baa43dfaa6707a9893196f6c74d577dabedd53285bf4ff1",
-                "sha256:b2d2b82a975f6e011b368f087066804e4952840da424cbfac7fc49bed1e0b2ab"
+                "sha256:7c22ea563ca3679377a0d0d5ce31a03bba4d103040fa16677251f482f2cac545",
+                "sha256:c889eaf8cf98b21ab6bdf69d2c86b93efc105decdbf0e7f98db245d943f8d75d"
             ],
             "index": "pypi",
-            "version": "==0.0.28"
+            "version": "==0.0.29"
         },
         "tornado": {
             "hashes": [


### PR DESCRIPTION
Dependency thoth-storages was used in version 0.0.28, but the current latest version is 0.0.29.