### PR TITLE
Update the trigger-build job to use the latest job API

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -14,4 +14,6 @@
       jobs:
         - trigger-build:
             vars:
-              webhook_url: "https://paas.upshift.redhat.com/oapi/v1/namespaces/thoth-test-core/buildconfigs/result-api"
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "result-api"

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -83,7 +83,7 @@ objects:
         - type: Generic
           generic:
             secretReference:
-              name: zuul-incoming-webhook
+              name: generic-webhook-secret
 
   - apiVersion: v1
     kind: ImageStream


### PR DESCRIPTION
Update buildconfig template to allow the buildconfig listen to generic webhook and update the zuul config file to use the latest version of trigger-build job API.