### PR TITLE
updates to store buildlogs analysis result to ceph

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -27,6 +27,7 @@ from thoth.common import init_logging
 from thoth.common import logger_setup
 from thoth.storages import AdvisersResultsStore
 from thoth.storages import AnalysisResultsStore
+from thoth.storages import BuildLogsAnalysisResultsStore
 from thoth.storages import DependencyMonkeyReportsStore
 from thoth.storages import GraphDatabase
 from thoth.storages import PackageAnalysisResultsStore
@@ -35,7 +36,7 @@ from thoth.storages import SolverResultsStore
 from thoth.storages import __version__ as thoth_storages_version
 
 
-__version__ = "0.6.0" + "+thoth_storage." + thoth_storages_version
+__version__ = "0.6.1" + "+thoth_storage." + thoth_storages_version
 
 
 init_logging()
@@ -59,6 +60,15 @@ def post_analysis_result():  # Ignore PyDocStyleBear
     adapter.connect()
     document_id = adapter.store_document(request.json)
     _LOGGER.info("Analyzer result stored with document_id %r", document_id)
+    return jsonify({"document_id": document_id}), 201, {"ContentType": "application/json"}
+
+
+@application.route("/api/v1/buildlogs-analysis-result", methods=["POST"])
+def post_buildlogs_analysis_result():  # Ignore PyDocStyleBear
+    adapter = BuildLogsAnalysisResultsStore()
+    adapter.connect()
+    document_id = adapter.store_document(request.json)
+    _LOGGER.info("Build Logs Analyzer result stored with document_id %r", document_id)
     return jsonify({"document_id": document_id}), 201, {"ContentType": "application/json"}
 
 


### PR DESCRIPTION
Added method to store build logs analysis result to ceph.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Depends-On: https://github.com/thoth-station/storages/pull/778